### PR TITLE
Updated API requestor behavior on curl error

### DIFF
--- a/Example.php
+++ b/Example.php
@@ -66,8 +66,8 @@ array(
     'items'=> array($customs_item)
 ));
 
-//Creating the shipment object. In this example, the objects are directly passed to the 
-//Shipment.create method, Alternatively, the Address and Parcel objects could be created 
+//Creating the shipment object. In this example, the objects are directly passed to the
+//Shipment.create method, Alternatively, the Address and Parcel objects could be created
 //using Address.create(..) and Parcel.create(..) functions respectively.
 $shipment = Shippo_Shipment::create(
 array(
@@ -94,7 +94,7 @@ $rates = Shippo_Shipment::get_shipping_rates(array('id'=> $shipment["object_id"]
 //Get the first rate in the rates results.
 $rate = $rates["results"][0];
 
-//Purchase the desired rate. sync=True indicates that the function will wait until the 
+//Purchase the desired rate. sync=True indicates that the function will wait until the
 //carrier returns a shipping label before it returns
 $transaction = Shippo_Transaction::create(array('rate'=> $rate["object_id"]));
 
@@ -112,4 +112,3 @@ if ($transaction["object_status"] == "SUCCESS"){
 }else {
     echo($transaction["messages"]);
 }
-?>

--- a/lib/Shippo/ApiRequestor.php
+++ b/lib/Shippo/ApiRequestor.php
@@ -238,8 +238,7 @@ class Shippo_ApiRequestor
         $httpBody = curl_exec($curl);
         
         $errorNum = curl_errno($curl);
-        if ($errorNum == CURLE_SSL_CACERT || $errorNum == CURLE_SSL_PEER_CERTIFICATE || $errorNum == 77) {
-            curl_setopt($curl, CURLOPT_CAINFO, dirname(__FILE__) . '/../cacert.pem');
+        if ($errorNum == 77) {
             $httpBody = curl_exec($curl);
         }
         

--- a/test/Shippo.php
+++ b/test/Shippo.php
@@ -34,8 +34,8 @@ require_once(dirname(__FILE__) . '/Shippo/Error.php');
 require_once(dirname(__FILE__) . '/Shippo/InvalidRequestErrorTest.php');
 require_once(dirname(__FILE__) . '/Shippo/ObjectTest.php');
 require_once(dirname(__FILE__) . '/Shippo/UtilTest.php');
-//
-// // // Shippo API Tests
+
+// Shippo API Tests
 require_once(dirname(__FILE__) . '/Shippo/AddressTest.php');
 require_once(dirname(__FILE__) . '/Shippo/ParcelTest.php');
 require_once(dirname(__FILE__) . '/Shippo/ShipmentTest.php');

--- a/test/Shippo/RateTest.php
+++ b/test/Shippo/RateTest.php
@@ -3,11 +3,6 @@
 class Shippo_RateTest extends Shippo_Test
 {
     
-    function setUp()
-    {
-        Shippo::setApiKey('dW5pdHRlc3Q6dW5pdHRlc3Q=');
-    }
-    
     public function testValidCreate()
     {
         $rate = self::getDefaultRate();

--- a/test/Shippo/ShipmentTest.php
+++ b/test/Shippo/ShipmentTest.php
@@ -3,11 +3,6 @@
 class Shippo_ShipmentTest extends Shippo_Test
 {
     
-    function setUp()
-    {
-        Shippo::setApiKey('dW5pdHRlc3Q6dW5pdHRlc3Q=');
-    }
-    
     public function testValidCreate()
     {
         $shipment = self::getDefaultShipment();


### PR DESCRIPTION
Updated the API Requestor to handle curl errors differently, removed duplication of setup up methods in test of shipment and rate.