### PR TITLE
Add encodeObjects if statement

### DIFF
--- a/lib/Shippo/ApiRequestor.php
+++ b/lib/Shippo/ApiRequestor.php
@@ -41,6 +41,8 @@ class Shippo_ApiRequestor
     {
         if ($d instanceof Shippo_ApiResource) {
             return self::utf8($d->id);
+        } else if ($d instanceof Shippo_Object) {
+            return self::utf8($d->object_id);
         } else if ($d === true) {
             return 'true';
         } else if ($d === false) {


### PR DESCRIPTION
I had to add this change in order to get custom_declarations to work in some situations, the custom declarations object was type Shippo_Object and the identifier was located in object_id, so it was not finding it with the existing code and failing on GB and DE addresses and possibly others.  Canada addresses sometimes worked, so I'm not sure if this is the correct way to fix this or if this a better way, but I thought I would send it over since my code is now working 100% of the time.