### PR TITLE
Travis badge now shows build status of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #Shippo PHP API wrapper
-[![Build Status](https://travis-ci.org/goshippo/shippo-php-client.svg)](https://travis-ci.org/goshippo/shippo-php-client)
+[![Build Status](https://travis-ci.org/goshippo/shippo-php-client.svg?branch=master)](https://travis-ci.org/goshippo/shippo-php-client)
 
 Shippo is a shipping API that connects you with [multiple shipping carriers](https://goshippo.com/carriers/) (such as USPS, UPS, DHL, Canada Post, Australia Post, UberRUSH and many others) through one interface.
 


### PR DESCRIPTION
The current Travis badge shows the status for the latest build, i've changed it to show the status of the master branch build instead.