### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To take advantage of configuration caching, you can set a config parameter in `c
 
 From here you can use the Shippo library anywhere in your application without setting the key when accessing it.
 
-###Testing
+### Testing
 After installing the dependencies above, the test suite may be run:
 
         ./vendor/bin/phpunit


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
