### PR TITLE
Fixed documentation typos

### DIFF
--- a/lib/Shippo/Address.php
+++ b/lib/Shippo/Address.php
@@ -18,7 +18,7 @@ class Shippo_Address extends Shippo_ApiResource
      * @param array|null $params
      * @param string|null $apiKey
      *
-     * @return Shippo_Adress Create an Address.
+     * @return Shippo_Address Create an Address.
      */
     public static function create($params = null, $apiKey = null)
     {

--- a/lib/Shippo/CarrierAccount.php
+++ b/lib/Shippo/CarrierAccount.php
@@ -18,7 +18,7 @@ class Shippo_CarrierAccount extends Shippo_ApiResource
     * @param array|null $params
     * @param string|null $apiKey
     *
-    * @return Shippo_CustomsItem Create a customs item.
+    * @return Shippo_CarrierAccount Create a carrier account.
     */
     public static function create($params = null, $apiKey = null)
     {
@@ -29,7 +29,7 @@ class Shippo_CarrierAccount extends Shippo_ApiResource
     /**
     * @param array|null $params
     *
-    * @return Shippo_Retrieve Get a customs item.
+    * @return Shippo_Retrieve Get a carrier account.
     */
     public static function retrieve($id, $apiKey = null)
     {
@@ -40,7 +40,7 @@ class Shippo_CarrierAccount extends Shippo_ApiResource
     /**
     * @param array|null $params
     *
-    * @return Shippo_All Get all the customs items.
+    * @return Shippo_All Get all carrier accounts.
     */
     public static function all($params = null, $apiKey = null)
     {
@@ -51,7 +51,7 @@ class Shippo_CarrierAccount extends Shippo_ApiResource
     /**
     * @param id of the CarrierAccount to be updated
     *
-    * @return Shippo_Retrieve Get a customs item.
+    * @return Shippo_Retrieve Get a carrier account.
     */
     public static function update($id, $params, $apiKey = null)
     {


### PR DESCRIPTION
I've run across some typos while developing with the latest SDK. Here are a couple fixes, though there may be more corrections needed