### PR TITLE
Prevent invalid array access

### DIFF
--- a/lib/Shippo/Util.php
+++ b/lib/Shippo/Util.php
@@ -12,7 +12,7 @@ abstract class Shippo_Util
     {
         if (!is_array($array))
             return false;
-        
+
         // TODO: generally incorrect, but it's correct given Shippo's response
         foreach (array_keys($array) as $k) {
             if (!is_numeric($k))
@@ -20,7 +20,7 @@ abstract class Shippo_Util
         }
         return true;
     }
-    
+
     /**
      * Recursively converts the PHP Shippo object to an array.
      *
@@ -32,7 +32,7 @@ abstract class Shippo_Util
         $results = array();
         foreach ($values as $k => $v) {
             // FIXME: this is an encapsulation violation
-            if ($k[0] == '_') {
+            if (is_string($k) && $k[0] == '_') {
                 continue;
             }
             if ($v instanceof Shippo_Object) {
@@ -45,7 +45,7 @@ abstract class Shippo_Util
         }
         return $results;
     }
-    
+
     /**
      * Converts a response from the Shippo API to the corresponding PHP object.
      *


### PR DESCRIPTION
PHP7.4 - https://www.php.net/manual/en/migration74.incompatible.php

> Trying to use values of type null, bool, int, float or resource as an
array (such as $null["key"]) will now generate a notice.