### PR TITLE
Fix Util:: convertShippoObjectToArray

### DIFF
--- a/lib/Shippo/Util.php
+++ b/lib/Shippo/Util.php
@@ -37,8 +37,6 @@ abstract class Shippo_Util
             }
             if ($v instanceof Shippo_Object) {
                 $results[$k] = $v->__toArray(true);
-            } else if (is_array($v)) {
-                $results[$k] = self::convertShippoObjectToArray($v);
             } else {
                 $results[$k] = $v;
             }


### PR DESCRIPTION
This causes errors, see PR #68 . I don't see why it's necessary to run simple arrays through this method anyway, the outcome is the same. 