### PR TITLE
Updating  Examples/get-rates-to-show-customer.php based on API Changes

### DIFF
--- a/examples/get-rates-to-show-customer.php
+++ b/examples/get-rates-to-show-customer.php
@@ -80,12 +80,12 @@ $shipment = Shippo_Shipment::create(
 array(
     'address_from'=> $from_address,
     'address_to'=> $to_address,
-    'parcels'=> array($parcel),
+    'parcel'=> $parcel,
     'async'=> false,
 ));
 
 // Rates are stored in the `rates` array inside the shipment object
-$rates = $shipment['rates'];
+$rates = $shipment['rates_list'];
 
 // You can now show those rates to the user in your UI.
 // Most likely you want to show some of the following fields:


### PR DESCRIPTION
These examples have not been updated in many moons and the API has changed. I'm sure all the others will need to be redone in some capacity, but I was just fixing this since I used it

Shippo_Shipment no longer accepts the 'parcels' key and instead only 'parcel'
The $shipment key is now 'rates_list' instead of 'rates'